### PR TITLE
Extend compiler support and improve table output

### DIFF
--- a/benchmark
+++ b/benchmark
@@ -20,7 +20,8 @@ TEMPLATED_SUPPORTED_LANGUAGES = ['C++', 'Java', 'D', 'Swift', 'Vox', 'Rust', 'Zi
 SUPPORTED_OPERATIONS = ['Check', 'Build']
 DEFAULT_PROGRAM_NAME = 'main'
 
-C_WARN_FLAGS = ['-Wall', '-Wextra']
+#C_WARN_FLAGS = ['-Wall', '-Wextra']
+C_WARN_FLAGS = ['-w']
 
 RUSTC_NO_WARNINGS_FLAGS = ['-A', 'warnings']  # flags that disable warnings for `rustc`
 RUSTC_FLAGS = []          # set to `RUSTC_NO_WARNINGS_FLAGS` to disable warnings
@@ -125,6 +126,9 @@ def factor_str(factor):
     return '{:.1f}'.format(factor)
 
 
+def repeat_to_length(string_to_expand, length):
+    return (string_to_expand * (int(length/len(string_to_expand))+1))[:length]
+
 def md_header(text, nr):        # Markdown header
     return '#' * nr + ' ' + text
 
@@ -144,15 +148,16 @@ def md_table(titles, rows):
     result += '| '
     for ix, col in enumerate(range(len(titles))):
         if ix == 2:
-            result += '---' + ' | '
+            result += repeat_to_length("-",len(titles[ix])) + ' | '
         else:
-            result += ':---:' + ' | '
+            result += ':' + repeat_to_length("-",len(titles[ix])-2) + ':' + ' | '
     result += '\n'
 
     for row in rows:
         result += '| '
-        for col in row:
-            result += str(col) + ' | '
+        for ix, cl in enumerate(range(len(titles))):
+            col = row[ix]
+            result += str(col) + repeat_to_length(" ",len(titles[ix])-len(str(col))) + ' | '
         result += '\n'
     return result
 
@@ -416,16 +421,16 @@ def benchmark_C_using_cproc(lang, execs, durs, gpaths, args, op, templated):
 def benchmark_C_and_Cxx_using_clang(lang, execs, durs, gpaths, args, op, templated):
     results = list()
     C_CLANG_FLAGS = C_WARN_FLAGS + ['-fno-color-diagnostics', '-fno-caret-diagnostics', '-fno-diagnostics-show-option']
-    CLANG_VERSIONS = range(5, 15)
     comp_flags = [] if op == 'Build' else ['-fsyntax-only']
-    for clang_version in CLANG_VERSIONS:
+    for clang_version in VERSIONS:
         if lang == 'C':
-            exe = which('clang-' + str(clang_version))
+            exe = which('clang' + str(clang_version))
         elif lang == 'C++':
-            exe = which('clang++-' + str(clang_version))
+            exe = which('clang++' + str(clang_version))
         else:
             assert(False)
         if exe is not None:
+            print(f"Clang version {clang_version}")
             version = sp.run([exe, '--version'], stdout=sp.PIPE).stdout.decode('utf-8').split()[2].split('-')[0]
             compile_file(src_paths=[gpaths[srcIdOf(lang, templated)]],
                          out_flag_and_exe=['-o', out_binary(lang)],
@@ -608,8 +613,8 @@ def benchmark_Go_using_go(execs, durs, gpaths, args, op, templated):
 def benchmark_Go_using_gccgo(execs, durs, gpaths, args, op, templated):
     results = list()
     lang = 'Go'
-    for gccgo_version in GCC_VERSIONS:
-        exe = which('gccgo-' + str(gccgo_version))
+    for gccgo_version in VERSIONS:
+        exe = which('gccgo' + str(gccgo_version))
         comp_flags = [] if op == 'Build' else ['-fsyntax-only', '-S']
         if exe is not None:
             execs[lang] = exe

--- a/benchmark
+++ b/benchmark
@@ -26,7 +26,8 @@ RUSTC_NO_WARNINGS_FLAGS = ['-A', 'warnings']  # flags that disable warnings for 
 RUSTC_FLAGS = []          # set to `RUSTC_NO_WARNINGS_FLAGS` to disable warnings
 
 ROOT_PATH = 'generated'
-GCC_VERSIONS = range(5, 15)
+RANGE = range(5, 15)
+VERSIONS = [""] + [f"-{i}" for i in RANGE]
 
 TABLE_TITLES = ['Lang-uage', 'Oper-ation', 'Temp-lated', 'Op Time [us/#fn]', 'Slowdown vs [Best]', 'Run Time [us/#fn]', 'Version', 'Exec']
 
@@ -336,8 +337,8 @@ def generate_code(args):
 def benchmark_Ada_using_gcc(lang, execs, durs, gpaths, args, op, templated):
     results = list()
     comp_flags = ['compile'] if op == 'Build' else ['check']
-    for gcc_version in GCC_VERSIONS:
-        exe = which('gnat-' + str(gcc_version))
+    for gcc_version in VERSIONS:
+        exe = which('gnat' + str(gcc_version))
         if exe is not None:
             version = sp.run([exe, '--version'], stdout=sp.PIPE).stdout.decode('utf-8').split()[1]
             compile_file(src_paths=[gpaths[srcIdOf(lang, templated)]],
@@ -358,11 +359,11 @@ def benchmark_Ada_using_gcc(lang, execs, durs, gpaths, args, op, templated):
 def benchmark_C_and_Cxx_using_gcc(lang, execs, durs, gpaths, args, op, templated):
     results = list()
     comp_flags = [] if op == 'Build' else ['-fsyntax-only']
-    for gcc_version in GCC_VERSIONS:
+    for gcc_version in VERSIONS:
         if lang == 'C':
-            exe = which('gcc-' + str(gcc_version))
+            exe = which('gcc' + str(gcc_version))
         elif lang == 'C++':
-            exe = which('g++-' + str(gcc_version))
+            exe = which('g++' + str(gcc_version))
         else:
             assert(False)
         if exe is not None:

--- a/benchmark
+++ b/benchmark
@@ -20,8 +20,7 @@ TEMPLATED_SUPPORTED_LANGUAGES = ['C++', 'Java', 'D', 'Swift', 'Vox', 'Rust', 'Zi
 SUPPORTED_OPERATIONS = ['Check', 'Build']
 DEFAULT_PROGRAM_NAME = 'main'
 
-#C_WARN_FLAGS = ['-Wall', '-Wextra']
-C_WARN_FLAGS = ['-w']
+C_WARN_FLAGS = ['-Wall', '-Wextra','-Wno-c++11-extensions']
 
 RUSTC_NO_WARNINGS_FLAGS = ['-A', 'warnings']  # flags that disable warnings for `rustc`
 RUSTC_FLAGS = []          # set to `RUSTC_NO_WARNINGS_FLAGS` to disable warnings
@@ -430,7 +429,6 @@ def benchmark_C_and_Cxx_using_clang(lang, execs, durs, gpaths, args, op, templat
         else:
             assert(False)
         if exe is not None:
-            print(f"Clang version {clang_version}")
             version = sp.run([exe, '--version'], stdout=sp.PIPE).stdout.decode('utf-8').split()[2].split('-')[0]
             compile_file(src_paths=[gpaths[srcIdOf(lang, templated)]],
                          out_flag_and_exe=['-o', out_binary(lang)],


### PR DESCRIPTION
Hi, 
Few additions made after using your great script! 
Prevent warnings for c++11 extensions to avoid clutering output.
Compiler support is extended by accounting for `clang` and `clang++` rather than limiting to executables with `-##` version number extension.
Table has been changed to show up with aligned column separators:
```
| Lang-uage | Oper-ation | Temp-lated | Op Time [us/#fn] | Slowdown vs [Best] | Run Time [us/#fn] | Version | Exec |
| :-------: | :--------: | ---------- | :--------------: | :----------------: | :---------------: | :-----: | :--: |
| C++       | Check      | No         | 15.0             | 1.0 [C++]          | N/A               | version | `g++` |
| C++       | Check      | No         | 26.8             | 1.8 [C++]          | N/A               | GCC     | `g++-10` |
| C++       | Check      | No         | 33.3             | 2.2 [C++]          | N/A               | 11.0.0  | `clang++` |
| C++       | Check      | No         | 383.5            | 25.5 [C++]         | N/A               | 12.0.0  | `clang++-12` |
| C++       | Check      | Yes        | 24.0             | 1.6 [C++]          | N/A               | version | `g++` |
| C++       | Check      | Yes        | 47.6             | 3.2 [C++]          | N/A               | GCC     | `g++-10` |
| C++       | Check      | Yes        | 52.2             | 3.5 [C++]          | N/A               | 11.0.0  | `clang++` |
| C++       | Check      | Yes        | 640.4            | 42.6 [C++]         | N/A               | 12.0.0  | `clang++-12` |
| C++       | Build      | No         | 134.4            | 1.0 [C++]          | 1818              | version | `g++` |
| C++       | Build      | No         | 460.0            | 3.4 [C++]          | 511               | GCC     | `g++-10` |
| C++       | Build      | No         | 219.0            | 1.6 [C++]          | 2662              | 11.0.0  | `clang++` |
| C++       | Build      | No         | 1765.1           | 13.1 [C++]         | 4564              | 12.0.0  | `clang++-12` |
| C++       | Build      | Yes        | 139.4            | 1.0 [C++]          | 1718              | version | `g++` |
| C++       | Build      | Yes        | 493.2            | 3.7 [C++]          | 372               | GCC     | `g++-10` |
| C++       | Build      | Yes        | 218.9            | 1.6 [C++]          | 2705              | 11.0.0  | `clang++` |
| C++       | Build      | Yes        | 2002.8           | 14.9 [C++]         | 4481              | 12.0.0  | `clang++-12` |
```
