### PR TITLE
nim: improve build time by 1.5x

### DIFF
--- a/benchmark
+++ b/benchmark
@@ -851,10 +851,11 @@ def benchmark_Nim(execs, durs, gpaths, args, op, templated):
     results = list()
     lang = 'Nim'
     exe = which('nim')
-    comp_flags = ['--hints:off']
+    comp_flags = ['--hints:off', '--checks:off', '--stacktrace:off']
     if op == 'Check':
         comp_flags += ['check']
     elif op == 'Build':
+        # the bottleneck is clang compilation
         comp_flags += ['c', '--gc:refc', '--opt:none']  # TODO detect when --gc:arc is available
     else:
         assert False


### PR DESCRIPTION
/cc @xflywind 

## note
the good news is that it's mostly the backend cgen that takes time:

clang -o /tmp/z01 generated/c/main.c
2s

XDG_CONFIG_HOME= nim c --compileonly -o:/tmp/z04x --nimcache:/tmp/c07f --checks:off --stacktrace:off --opt:none --hints:off generated/nim/main.nim
1.18s

XDG_CONFIG_HOME= nim c -o:/tmp/z05 --nimcache:/tmp/c07f --checks:off --stacktrace:off --opt:none --hints:off generated/nim/main.nim
4.1s

## note 1
with `--hint:cc --listcmd` it shows:
`clang -c  -w -ferror-limit=3   -I/Users/timothee/git_clone/nim/Nim_devel/lib -I/Users/timothee/git_clone/nim/temp/compiler-benchmark/generated/nim -o /tmp/c08d/@mmain.nim.c.o /tmp/c08d/@mmain.nim.c`
2.8s


## note 2
https://github.com/nordlow/compiler-benchmark/issues/8#issuecomment-821872378
> I've added support for check and debug builds support. Feel free to modify and propose pull requests as you wish. compiler-benchmark currenly only tests debug build performance.

the benchmark should allow reporting not just debug builds; for eg nim enables lots of checks by default which are optimized for development speed/improved debugging, but can slow down compilation times; languages shouldn't be penalized for having more debugging checks on by default :)

## note 3
`--gc:arc` is about 1.2x slower; the cgen contains this:
```
N_LIB_PRIVATE N_NIMCALL(NI64, add_int64_n77_h5_main_23116)(NI64 x) {
	NI64 result;
	NI64 T1_;
NIM_BOOL* nimErr_;
{nimErr_ = nimErrorFlag();
	result = (NI64)0;
	T1_ = (NI64)0;
	T1_ = add_int64_n77_h4_main_23113(x);
	if (NIM_UNLIKELY(*nimErr_)) goto BeforeRet_;
	result = (NI64)((NI64)(x + T1_) + IL64(47509));
	goto BeforeRet_;
	}BeforeRet_: ;
	return result;
}
```

which has more instructions compared to gc:refc:
```
N_LIB_PRIVATE N_NIMCALL(NI64, add_int64_n77_h5_main_23116)(NI64 x) {
	NI64 result;
	NI64 T1_;
{	result = (NI64)0;
	T1_ = (NI64)0;
	T1_ = add_int64_n77_h4_main_23113(x);
	result = (NI64)((NI64)(x + T1_) + IL64(47509));
	goto BeforeRet_;
	}BeforeRet_: ;
	return result;
}
```

## note 4
codegen generates:
```nim
N_LIB_PRIVATE N_NIMCALL(int, add_cint_n68_h73_main_20620)(int x) {
	int result;
	int T1_;
{	result = (int)0;
	T1_ = (int)0;
	T1_ = add_cint_n68_h72_main_20617(x);
	result = (NI32)((NI32)(x + T1_) + ((NI32) 42695));
	goto BeforeRet_;
	}BeforeRet_: ;
	return result;
}
```
if it generated the following simplified code isntead:
```
N_LIB_PRIVATE N_NIMCALL(int, add_cint_n68_h73_main_20620)(int x) {
	int T1_ = add_cint_n68_h72_main_20617(x);
	return (NI32)((NI32)(x + T1_) + ((NI32) 42695));
}
```

it would bring down clang compilation time by ~1.15x, not sure whether it's worth it since in practice other factors dominate (eg nim VM, IC etc)