### PR TITLE
Use rustc --emit=metadata

### DIFF
--- a/benchmark
+++ b/benchmark
@@ -926,18 +926,10 @@ def benchmark_Rust(results, code_paths, args, op, templated):
 
         exe = match_lang(args, lang, 'rustc')
         if exe:
-            # See: https://stackoverflow.com/questions/53250631/does-rust-have-a-way-to-perform-syntax-and-semantic-analysis-without-generating/53250674#53250674
-            # See: https://stackoverflow.com/questions/51485765/run-rustc-to-check-a-program-without-generating-any-files
-            # Alternatives:
-            # - `rustc --emit=metadata -Z no-codegen`
-            # - Not yet in stable: `rustc -Z no-codegen`
-            # - 'rustc', '--crate-type', 'lib', '--emit=mir', '-o', '/dev/null', '--test'
             version = sp.run([exe, '--version'], stdout=sp.PIPE).stdout.decode('utf-8').split()[1]
             if op == 'Check':
-                if channel == 'nightly':
-                    check_args = ['-Z', 'no-codegen']  # TODO why is this not available on stable yet?
-                else:
-                    check_args = ['--emit=mir', '-o', '/dev/null']  # Used by Flycheck. Twice as slow as `-Z no-codegen`
+                # `cargo check` uses `rustc --emit=metadata`
+                check_args = ['--emit=metadata']
                 out_flag_and_exe = []
             elif op == 'Build':
                 out_flag_and_exe = ['-o', out_binary(lang)]


### PR DESCRIPTION
This has been stabilized quite a while ago and is what `cargo check` uses.

Local benchmark result (on a laptop) before this PR:

```restructuredtext
# Benchmark:
- Generating generated/rust/main_0.rs took 0.132 seconds (Rust)
- Check took 3.048 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.59.0)
- Check took 1.801 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.61.0-nightly)
- Generating generated/rust/main_t_0.rs took 0.153 seconds (Rust)
- Check took 2.738 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.59.0)
- Check took 1.995 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.61.0-nightly)
- Build took 5.587 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.59.0)
- Build took 5.683 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.61.0-nightly)
- Build took 3.478 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.59.0)
- Build took 3.577 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.61.0-nightly)

| Lang-uage | Temp-lated | Check Time [us/fn] | Compile Time [us/fn] | Build Time [us/fn] | Run Time [us/fn] | Check RSS [kB/fn] | Build RSS [kB/fn] | Exec Version | Exec Path | 
| :-------: | ---------- | :----------------: | :------------------: | :----------------: | :--------------: | :---------------: | :---------------: | :----------: | :-------: | 
| Rust      | No         |  180.1 (best)      | N/A                  |  568.3 (1.6x)      |   9321 (best)    |   22.0 (best)     |   43.8 (1.3x)     | 1.61.0-nightly | rustc     | 
| Rust      | Yes        |  199.5 (1.1x)      | N/A                  |  357.7 (best)      |  10132 (1.1x)    |   26.0 (1.2x)     |   33.8 (best)     | 1.61.0-nightly | rustc     | 
```

And after this PR:

```restructuredtext
# Benchmark:
- Generating generated/rust/main_0.rs took 0.134 seconds (Rust)
- Check took 2.246 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.59.0)
- Check took 2.232 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.61.0-nightly)
- Generating generated/rust/main_t_0.rs took 0.147 seconds (Rust)
- Check took 2.189 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.59.0)
- Check took 2.217 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.61.0-nightly)
- Build took 5.767 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.59.0)
- Build took 6.147 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.61.0-nightly)
- Build took 3.490 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.59.0)
- Build took 3.547 seconds (using "/home/bjorn/.cargo/bin/rustc" version 1.61.0-nightly)

| Lang-uage | Temp-lated | Check Time [us/fn] | Compile Time [us/fn] | Build Time [us/fn] | Run Time [us/fn] | Check RSS [kB/fn] | Build RSS [kB/fn] | Exec Version | Exec Path | 
| :-------: | ---------- | :----------------: | :------------------: | :----------------: | :--------------: | :---------------: | :---------------: | :----------: | :-------: | 
| Rust      | No         |  223.2 (1.0x)      | N/A                  |  614.7 (1.7x)      |  12401 (1.3x)    |   21.8 (best)     |   43.8 (1.3x)     | 1.61.0-nightly | rustc     | 
| Rust      | Yes        |  221.7 (best)      | N/A                  |  354.7 (best)      |   9305 (best)    |   25.9 (1.2x)     |   33.7 (best)     | 1.61.0-nightly | rustc     | 
```

`--emit=metadata` is faster than `--emit=mir -o /dev/null` which was previously used on stable. For some reason it is slightly slower than `-Zno-codegen`, which was previously used on nightly.