### PR TITLE
ocamlopt: use -linscan option

### DIFF
--- a/benchmark
+++ b/benchmark
@@ -802,7 +802,7 @@ def benchmark_OCaml(results, code_paths, args, op, templated, bytecode):
                      runner=([which('ocamlrun')] if
                              bytecode else
                              True),
-                     exe_flags=['-c'] if bytecode else [],
+                     exe_flags=['-c'] if bytecode else  ['-linscan'],
                      args=args,
                      op=op,
                      compiler_version=version,


### PR DESCRIPTION
Thanks for organizing this benchmark! Very cool.

The OCaml native-code compiler has a register allocator which is
well-known to take a long time in some pathological scenarios that are
rare in human-written programs, but common in some computer-generated
programs. The programs generated by this benchmark hit exactly this
bad situation.

The OCaml compiler also provides a linear-scan register allocator
without a performance issue for such programs. It is not activated by
default, but enabled as an option (`-linscan`) and users that hit this
limitation with the standard register allocator are invited to use it.

This commit passes the '-linscan' option to the native
compiler (ocamlopt) to enable the linear-scan register allocator.

On my machine, ocamlopt build time goes from 20s to 8s with this change.

One could debate whether non-default options should we passed to get
a representative benchmark, butin this case I think the choice is very
reasonable:

- A human user facing the same compile-time issue would be advised to
  pass this option.
- The cost here comes from the benchmark generating code very
  different from idiomatic programs, which is arguably a limitation
  of the benchmark (and not of the compiler itself), so alleviating
  it with specific options seems reasonable.