### PR TITLE
Add Pareas

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ compilers. Supported languages are:
 - [V](https://vlang.io/) (using `v`),
 - [Vox](https://github.com/MrSmith33/vox) (using `vox`),
 - [C3](https://github.com/c3lang/c3c) (using `c3c`),
+- [Pareas](https://github.com/Snektron/pareas) (using `pareas`),
 
 ## Languages with Bytecode Compilers:
 

--- a/benchmark
+++ b/benchmark
@@ -21,7 +21,7 @@ from timeit import default_timer as timer
 from process_timer import ProcessTimer
 
 
-SUPPORTED_LANGUAGES = ['C', 'C++', 'Ada', 'C#', 'Swift', 'Java', 'D', 'Vox', 'Rust', 'Nim', 'Zig', 'Go', 'V', 'C3', 'Julia', 'OCaml']
+SUPPORTED_LANGUAGES = ['C', 'C++', 'Ada', 'C#', 'Swift', 'Java', 'D', 'Vox', 'Rust', 'Nim', 'Zig', 'Go', 'V', 'C3', 'Julia', 'OCaml', 'Pareas']
 TEMPLATED_SUPPORTED_LANGUAGES = ['C++', 'Java', 'D', 'Swift', 'Vox', 'Rust', 'Zig', 'V', 'C3', 'Julia']
 SUPPORTED_OPERATIONS = ['Check', 'Compile', 'Build']
 DEFAULT_PROGRAM_NAME = 'main'
@@ -407,6 +407,12 @@ def main():
     if 'Java' in args.languages:
         if 'Build' in args.operations:
             benchmark_Java(results=results, code_paths=code_paths, args=args, op='Build', templated=False)
+
+    if 'Pareas' in args.languages:
+        if 'Check' in args.operations:
+            benchmark_Pareas(results=results, code_paths=code_paths, args=args, op='Check', templated=False)
+        if 'Build' in args.operations:
+            benchmark_Pareas(results=results, code_paths=code_paths, args=args, op='Build', templated=False)
 
     # Julia and Ocaml take too long otherwise. So let them participate by
     # truncating size because ops/function are measured
@@ -974,6 +980,22 @@ def benchmark_Java(results, code_paths, args, op, templated):
                      templated=templated,
                      results=results)
 
+def benchmark_Pareas(results, code_paths, args, op, templated):
+    lang = 'Pareas'
+    exe = match_lang(args, lang, 'pareas')
+    if exe:
+        compile_file(code_paths,
+                     out_flag_and_exe=['-o', out_binary(lang)],
+                     exe=exe,
+                     runner=False,
+                     exe_flags=['--check'] if op == 'Check' else [],
+                     args=args,
+                     op=op,
+                     compiler_version='unknown',
+                     lang=lang,
+                     templated=templated,
+                     results=results)
+
 
 def benchmark_Julia(results, code_paths, args, op, templated):
     lang = 'Julia'
@@ -1154,6 +1176,8 @@ def long_types_of_lang(lang):
         return ['float']
     elif lang == 'ada':
         return ['Long_Integer']  # gnat
+    elif lang == 'pareas':
+        return ['int']
     else:
         return None
 
@@ -1171,6 +1195,8 @@ def language_file_extension(lang):
         return 'vx'
     elif lang == 'ada':
         return 'adb'
+    elif lang == 'pareas':
+        return 'par'
     else:
         return lang
 
@@ -1236,6 +1262,8 @@ def generate_test_function_call(lang, findex, typ, f, templated):
                                                                           X='[' + typ + ']' if templated else ''))
     elif lang == 'swift':
         f.write(Tm('    ${T}_sum += add_${T}_n${N}(x: ${N})').substitute(T=typ, N=str(findex)))
+    elif lang == 'pareas':
+        f.write(Tm('    ${T}_sum = ${T}_sum + add_${T}_n${N}[${N}]').substitute(T=typ, N=str(findex)))
     else:
         f.write(Tm('    ${T}_sum += add_${T}_n${N}(${N})').substitute(T=typ, N=str(findex)))
 
@@ -1302,6 +1330,8 @@ def generate_test_language_specific_postfix(lang, types, f):
         f.write(Tm('\n\n').substitute(T=types[0]))
     elif lang == 'c3':
         f.write(Tm('        return (int)(${T}_sum);\n}\n').substitute(T=types[0]))
+    elif lang == 'pareas':
+        f.write(Tm('    return ${T}_sum;\n}\n').substitute(T=types[0]))
     elif lang == 'julia':
         f.write(Tm('''    return ${T}_sum;
 end
@@ -1386,6 +1416,8 @@ def generate_test_function_definition(args, lang, typ, findex, fheight, f,
             expr = 'x +. (' + function_name(typ, findex, fheight - 1) + xtarg + ' x) +. ' + nconst + '.0'
         elif lang == 'swift':
             expr = 'x + ' + function_name(typ, findex, fheight - 1) + '(x: ' + xtarg + 'x) + ' + nconst
+        elif lang == 'pareas':
+            expr = 'x + ' + function_name(typ, findex, fheight - 1) + '[x] + ' + nconst
         else:
             expr = 'x + ' + function_name(typ, findex, fheight - 1) + '(' + xtarg + 'x) + ' + nconst
 
@@ -1475,6 +1507,8 @@ def generate_test_function_definition(args, lang, typ, findex, fheight, f,
     elif lang == 'julia':
         f.write(Tm('function ${F}(x${QT})${QT}\n    return ${X}\nend;\n').substitute(QT=('' if templated else ('::' + typ)),
                                                                                      F=str(fname), N=nconst, H=str(fheight), X=expr))
+    elif lang == 'pareas':
+        f.write(Tm('fn ${F}[x: ${T}]: ${T} { return ${X}; }\n').substitute(T=typ, F=str(fname), X=expr))
 
 
 def generate_test_main_header(lang, types, f, templated):
@@ -1510,6 +1544,8 @@ def generate_test_main_header(lang, types, f, templated):
         f.write('let () = \n')
     elif lang == 'nim':
         f.write('when isMainModule:\n')
+    elif lang == 'pareas':
+        f.write('fn main[]: int {\n')
     else:
         assert False
 
@@ -1544,6 +1580,8 @@ def generate_main_test_function_variable(lang, typ, f, templated):
         f.write(Tm('    ${T}_sum${QT} = 0;\n').substitute(T=typ, QT=(('::' + typ) if templated else '')))
     elif lang == 'ocaml':
         f.write(Tm('    let ${T}_sum = 0.0 in\n').substitute(T=typ))
+    elif lang == 'pareas':
+        f.write(Tm('    var ${T}_sum: ${T} = 0;\n').substitute(T=typ))
     else:
         assert False
 
@@ -1628,6 +1666,8 @@ def generate_test_program_2(function_count, lang, templated):
 end;
 ''').substitute(QT=('' if templated else ('::' + typ)), N=str(findex)))
                     f.write('\n')
+                elif lang == 'pareas':
+                    f.write(Tm('fn add_${T}_n${N}[x: ${T}]: ${T} { return x + ${N}; }').substitute(T=typ, N=str(findex)))
 
         # MAIN HEADER
         if lang in ['c', 'c++']:
@@ -1653,6 +1693,8 @@ end;
         elif lang == 'julia':
             f.write(Tm('''function main()::${T}
 ''').substitute(T=types[0]))
+        elif lang == 'pareas':
+            f.write(Tm('fn main[]: ${T} {\n').substitute(T=types[0]))
         else:
             assert False
 
@@ -1676,11 +1718,16 @@ end;
             elif lang == 'julia':
                 f.write(Tm('''    ${T}_sum${QT} = 0;
 ''').substitute(QT=('' if templated else ('::' + typ))))
+            elif lang == 'pareas':
+                f.write(Tm('    var ${T}_sum: ${T} = 0;\n').substitute(T=typ))
             else:
                 assert False
 
-            for findex in range(0, function_count):
-                f.write(Tm('''    ${T}_sum += add_${T}_n${N}(${N});
+            if lang == 'pareas':
+                f.write(Tm('    ${T}_sum += add_${T}_n${N}[${N}];').substitute(T=typ, N=str(findex)))
+            else:
+                for findex in range(0, function_count):
+                    f.write(Tm('''    ${T}_sum += add_${T}_n${N}(${N});
 ''').substitute(T=typ, N=str(findex)))
 
         if lang == 'rust':


### PR DESCRIPTION
For fun I've added the GPU-accelerated compiler which I wrote for my thesis. The language it compiles is very simple, but is just about enough for this benchmark, and I thought it would be interesting to compare.

Here are some results with some compilers that I had laying around with `./benchmark --function-count=200 --function-depth=200 --run-count=1 --languages=pareas,c:tcc,Zig,rust,D:dmd --ops=Check,Build`. CPU is a Ryzen R7 3700X, GPU is a Radeon RX 580X (using the Futhark OpenCL backend), OS is Void Linux with kernel 5.16. 

| Lang-uage | Temp-lated | Check Time [us/fn] | Compile Time [us/fn] | Build Time [us/fn] | Run Time [us/fn] | Check RSS [kB/fn] | Build RSS [kB/fn] | Exec Version | Exec Path | 
| :-------: | ---------- | :----------------: | :------------------: | :----------------: | :--------------: | :---------------: | :---------------: | :----------: | :-------: | 
| D         | No         |    9.4 (3.4x)      | N/A                  |    N/A             |    N/A           |    4.7 (10.2x)    |   10.3 (22.4x)    | v2.098.0     | dmd       | 
| D         | Yes        |   17.7 (6.3x)      | N/A                  |    N/A             |    N/A           |   13.4 (29.1x)    |   19.8 (43.1x)    | v2.098.0     | dmd       | 
| C         | No         |    2.8 (best)      | N/A                  |    2.9 (best)      |     15 (best)    |    0.5 (best)     |    0.5 (best)     | 0.9.27       | tcc       | 
| Zig       | No         |   59.8 (21.4x)     | N/A                  |  252.7 (87.2x)     |    111 (7.3x)    |   21.9 (47.6x)    |   35.1 (76.5x)    | 0.10.0-dev.1068+ca97caab8 | zig       | 
| Zig       | Yes        |   72.9 (26.1x)     | N/A                  |  266.0 (91.8x)     |    109 (7.2x)    |   29.9 (64.9x)    |   41.0 (89.4x)    | 0.10.0-dev.1068+ca97caab8 | zig       | 
| Rust      | No         |  101.6 (36.3x)     | N/A                  |  296.8 (102.4x)    |   1544 (102.2x)  |   15.1 (32.9x)    |   33.3 (72.5x)    | 1.61.0-nightly | rustc     | 
| Rust      | Yes        |  115.8 (41.4x)     | N/A                  |  195.2 (67.3x)     |   1551 (102.6x)  |   17.7 (38.5x)    |   21.8 (47.6x)    | 1.61.0-nightly | rustc     | 
| Pareas    | No         |   13.2 (4.7x)      | N/A                  |  433.8 (149.6x)    |    N/A           |    5.3 (11.5x)    |    5.4 (11.8x)    | unknown      | pareas    | 

(Note that dmd couldn't compile some files).

My particular interest here is the `Check` time, which is the specific part that I worked on in this compiler. In the above example, generated with the same parameters as in the project readme, it gets relatively close but still seems to suffer from some overhead. The story changes when we increase the size of the source files (and disable codegen):
```
| Lang-uage | Temp-lated | Check Time [us/fn] | Compile Time [us/fn] | Build Time [us/fn] | Run Time [us/fn] | Check RSS [kB/fn] | Build RSS [kB/fn] | Exec Version | Exec Path | 
| :-------: | ---------- | :----------------: | :------------------: | :----------------: | :--------------: | :---------------: | :---------------: | :----------: | :-------: | 
| C         | No         |    7.8 (3.3x)      | N/A                  | N/A                | N/A              |    0.5 (1.6x)     | N/A               | 0.9.27       | tcc       | 
| Pareas    | No         |    2.4 (best)      | N/A                  | N/A                | N/A              |    0.3 (best)     | N/A               | unknown      | pareas    | 
```
(`./benchmark --function-count=1000 --function-depth=1000 --run-count=1 --languages=C:tcc,Pareas --ops=Check`)

Note that pareas needs to be at least version `ead2de65619a0706ffc98d1afcc77a57bb9a66f6`. Furthermore, the compiler suffers from a large startup overhead because the runtime has to compile the OpenCL/CUDA kernels. For this reason I've added a caching system to my compiler, such that the first run of the compiler on a particular system saves the compiled kernels for later use. I believe this is fair since its a one-time setup cost which does not depend on the program to be compiled. For reference, compiling those kernels takes about 7 seconds on my system.